### PR TITLE
Ignore order on array matching spec

### DIFF
--- a/spec/models/pingdom_api_spec.rb
+++ b/spec/models/pingdom_api_spec.rb
@@ -158,7 +158,7 @@ describe PingdomApi do
 				hash = {'key' => 'data', 'key2' => 'data2'}
 				api.send(:record_alert, 'mykey', hash)
 				alerts = api.get_all_alerts
-				expect(alerts).to eq(expected_results_from_all_alerts)
+				expect(alerts).to match_array(expected_results_from_all_alerts)
 			end
 		end
 


### PR DESCRIPTION
We don’t mind about the order that records are stored, and this test
was failing for me because of ordering. This fixes that.