### PR TITLE
Support old message format for pingdom

### DIFF
--- a/spec/requests/pingdom_webhook_spec.rb
+++ b/spec/requests/pingdom_webhook_spec.rb
@@ -61,18 +61,37 @@ describe 'GET /pingdom_webhook/:service_id' do
       let(:message) { %({"check": "", "action": "#{action}", "incidentid": "", "description": "DESCRIPTION"}) }
 
       context 'when action is "assign"' do
-        let(:action) { 'assign' }
-        let(:service_id) { 'new' }
-
-        it_behaves_like 'for down message'
+        include_examples 'for down message' do
+          let(:action) { 'assign' }
+          let(:service_id) { 'new' }
+        end
       end
 
       context 'when action is "notify_of_close"' do
-        let(:action) { 'notify_of_close' }
-        let(:service_id) { 'existing' }
-
-        it_behaves_like 'for up message'
+        include_examples 'for up message' do
+          let(:action) { 'notify_of_close' }
+          let(:service_id) { 'existing' }
+        end
       end
     end
+
+    context 'for a valid message - old format' do
+      let(:message) { %(PingdomAlert #{action}: some.service (DESCRIPTION) is #{action} since 2015-03-10 16:58:19 GMT +0000) }
+
+      context 'when action is "assign"' do
+        include_examples 'for down message' do
+          let(:action) { 'DOWN' }
+          let(:service_id) { 'new' }
+        end
+      end
+
+      context 'when action is "notify_of_close"' do
+        include_examples 'for up message' do
+          let(:action) { 'UP' }
+          let(:service_id) { 'existing' }
+        end
+      end
+    end
+
   end
 end

--- a/spec/requests/pingdom_webhook_spec.rb
+++ b/spec/requests/pingdom_webhook_spec.rb
@@ -1,5 +1,29 @@
 require 'spec_helper'
 
+shared_examples 'for down message' do
+  it 'creates a new alert' do
+    expect(Alert.exists?(existing_alert_key)).to be true
+  end
+
+  it 'the alert contains message identifying the problem with the service' do
+    expect(Alert.fetch(new_alert_key).message).to eql("#{service_id}: DESCRIPTION")
+  end
+
+  it 'returns 200 success' do
+    expect(last_response).to be_ok
+  end
+end
+
+shared_examples 'for up message' do
+  it 'removes the existing alert' do
+    expect(Alert.exists?(existing_alert_key)).to be false
+  end
+
+  it 'returns 200 success' do
+    expect(last_response).to be_ok
+  end
+end
+
 describe 'GET /pingdom_webhook/:service_id' do
   def app
     SupportApp
@@ -33,37 +57,21 @@ describe 'GET /pingdom_webhook/:service_id' do
       end
     end
 
-    context 'for a valid message - json' do
-      let(:message) { '{"check": "", "action": "' + action + '", "incidentid": "", "description": "DESCRIPTION"}' }
+    context 'for a valid message - new format' do
+      let(:message) { %({"check": "", "action": "#{action}", "incidentid": "", "description": "DESCRIPTION"}) }
 
       context 'when action is "assign"' do
         let(:action) { 'assign' }
         let(:service_id) { 'new' }
 
-        it 'creates a new alert' do
-          expect(Alert.exists?(existing_alert_key)).to be true
-        end
-
-        it 'the alert contains message identifying the problem with the service' do
-          expect(Alert.fetch(new_alert_key).message).to eql("#{service_id}: DESCRIPTION")
-        end
-
-        it 'returns 200 success' do
-          expect(last_response).to be_ok
-        end
+        it_behaves_like 'for down message'
       end
 
       context 'when action is "notify_of_close"' do
         let(:action) { 'notify_of_close' }
         let(:service_id) { 'existing' }
 
-        it 'removes the existing alert' do
-          expect(Alert.exists?(existing_alert_key)).to be false
-        end
-
-        it 'returns 200 success' do
-          expect(last_response).to be_ok
-        end
+        it_behaves_like 'for up message'
       end
     end
   end

--- a/spec/services/pingdom_webhook_spec.rb
+++ b/spec/services/pingdom_webhook_spec.rb
@@ -2,6 +2,30 @@ require 'spec_helper'
 
 require 'services/pingdom_webhook'
 
+shared_examples 'for assign/down message' do
+  it { is_expected.to be true }
+
+  it 'creates a new alert for the service' do
+    subject
+
+    expect(Alert.exists?(service_alert_key)).to be true
+  end
+end
+
+shared_examples 'for notify_of_close/up message' do
+  before do
+    Alert.create(service_alert_key, '{}')
+  end
+
+  it { is_expected.to be true }
+
+  it 'removes the existing alert' do
+    subject
+
+    expect(Alert.exists?(service_alert_key)).to be false
+  end
+end
+
 describe PingdomWebhook do
   let(:service_id) { 'SOME_SERVICE' }
   let(:service_alert_key) { "#{described_class::REDIS_KEY_PREFIX}/#{service_id}"}
@@ -16,30 +40,31 @@ describe PingdomWebhook do
 
       it { is_expected.to be false }
     end
-    context 'for message with "assign" action' do
-      let(:message) { '{"check": "", "action": "assign", "incidentid": "", "description": ""}' }
 
-      it { is_expected.to be true }
-
-      it 'creates a new alert for the service' do
-        subject
-
-        expect(Alert.exists?(service_alert_key)).to be true
+    context 'for new json format' do
+      context 'for message with "assign" action' do
+        include_examples 'for assign/down message' do
+          let(:message) { '{"check": "", "action": "assign", "incidentid": "", "description": ""}' }
+        end
+      end
+      context 'for message with "notify_of_close" action' do
+        include_examples 'for notify_of_close/up message' do
+          let(:message) { '{"check": "", "action": "notify_of_close", "incidentid": "", "description": ""}' }
+        end
       end
     end
-    context 'for message with "notify_of_close" action' do
-      let(:message) { '{"check": "", "action": "notify_of_close", "incidentid": "", "description": ""}' }
 
-      before do
-        Alert.create(service_alert_key, '{}')
+    context 'for old text format' do
+      context 'for DOWN message' do
+        include_examples 'for assign/down message' do
+          let(:message) { 'PingdomAlert DOWN: some.service (DESCRIPTION) is DOWN since 2015-03-10 16:58:19 GMT +0000' }
+        end
       end
 
-      it { is_expected.to be true }
-
-      it 'removes the existing alert' do
-        subject
-
-        expect(Alert.exists?(service_alert_key)).to be false
+      context 'for UP message' do
+        include_examples 'for notify_of_close/up message' do
+          let(:message) { 'PingdomAlert UP: some.service (DESCRIPTION) is UP since 2015-03-10 16:58:19 GMT +0000' }
+        end
       end
     end
   end


### PR DESCRIPTION
Most our apps currently use the old message format, so it should be supported. 

I also realised, that if one single app has multiple checks, the alerting won't work correctly. One check can cause an alert and a different check can remove it.