### PR TITLE
Support lower limits on current user alerts

### DIFF
--- a/config/realtime_analytic_limits.json
+++ b/config/realtime_analytic_limits.json
@@ -3,7 +3,8 @@
     {
       "name": "PVB",
       "profile_id": "79096907",
-      "limit": 100
+      "lower_limit": 10,
+      "upper_limit": 100
     }
   ]
 }

--- a/models/traffic_spike.rb
+++ b/models/traffic_spike.rb
@@ -22,14 +22,14 @@ class TrafficSpike
   attr_reader :config
 
   def current_users
-    RealTimeAnalytics.instance.current_visitor_count(config["profile_id"])
+    @current_users ||= RealTimeAnalytics.instance.current_visitor_count(config["profile_id"])
   end
 
   def unacceptable?
-    current_users > config["limit"]
+    current_users < config["lower_limit"] || current_users > config["upper_limit"]
   end
 
   def alert
-    "#{config["name"]} currently has #{current_users} users! (we don't expect more than #{config["limit"]})"
+    "#{config["name"]} currently has #{current_users} users! (we expect between #{config["lower_limit"]} and #{config["upper_limit"]})"
   end
 end


### PR DESCRIPTION
This doesn't have tests, but I'm rapidly reaching the end of my time on 2nd line, so thought it best to commit first, and see if I get time to add times before I leave for a long weekend.

This adds upper and lower limits on what is the expected number of current users for a system. This is set in the json config file.