### PR TITLE
Prefix alert key with "alert:" to allow non-alert usage of Redis.

### DIFF
--- a/models/alert.rb
+++ b/models/alert.rb
@@ -2,27 +2,34 @@ require 'redis'
 class Alert < Struct.new(:key, :value)
 
   def self.fetch_all
-    redis.keys("*").collect { |key| new(key,redis.get(key)) }
+    redis.keys(cache_key("*")).collect do |cache_key|
+      fetch(cache_key)
+    end
   end
 
   def self.fetch(key)
-    new(key, redis.get(key))
+    cache_key = cache_key(key)
+    new(cache_key, redis.get(cache_key))
   end
 
   def self.exists?(key)
-    redis.exists(key)
+    cache_key = cache_key(key)
+    redis.exists(cache_key)
   end
 
   def self.create(key, data)
-    redis.set(key, encode_payload(data))
+    cache_key = cache_key(key)
+    redis.set(cache_key, encode_payload(data))
   end
 
   def self.destroy(key)
-    redis.del(key)
+    cache_key = cache_key(key)
+    redis.del(cache_key)
   end
 
-  def self.destroy_all(keys)
-    keys = redis.keys(keys)
+  def self.destroy_all(key_pattern)
+    cache_key = cache_key(key_pattern)
+    keys = redis.keys(cache_key)
     redis.del(keys) unless keys.empty?
   end
 
@@ -46,5 +53,9 @@ class Alert < Struct.new(:key, :value)
 
   def self.redis
     @redis ||= Redis.new(:url => ENV["REDISCLOUD_URL"])
+  end
+
+  def self.cache_key key
+    key[/^alert:/] ? key : "alert:#{key}"
   end
 end


### PR DESCRIPTION
* Without this change it is not possible to store non-alert data in Redis.