### PR TITLE
Don't ask for zulu time, but whatever is the account default.

### DIFF
--- a/services/ir_pagerduty.rb
+++ b/services/ir_pagerduty.rb
@@ -32,8 +32,8 @@ class IRPagerduty < PagerDuty::Full
     dateStr = Date.today.to_s
     users = self.Schedule.users(
         sid,
-        since_date=URI.escape(dateStr + "T10:01Z"),
-        until_date=URI.escape(dateStr + "T16:59Z")
+        since_date=URI.escape(dateStr + "T10:01"),
+        until_date=URI.escape(dateStr + "T16:59")
     )['users']
 
     # PagerDuty class has no method to get contact_methods so we must do it manually

--- a/services/whos_out_of_hours.rb
+++ b/services/whos_out_of_hours.rb
@@ -51,8 +51,8 @@ module WhosOutOfHours
     dateStr = Date.today.to_s
     users = IRPagerduty.new.Schedule.users(
         sid,
-        since_date=URI.escape(dateStr + "T17:00Z"),
-        until_date=URI.escape(dateStr + "T22:59Z")
+        since_date=URI.escape(dateStr + "T17:00"),
+        until_date=URI.escape(dateStr + "T22:59")
     )['users']
 
     users.map { |user| user['name'] }


### PR DESCRIPTION
Our account-wide timezone in pagerduty is set up to be London, and our schedule is 10:00 - 17:00, but the dashboard is asking for zulu time, which would be 09:00-16:00, which does include both managers.
The api call we're using is https://developer.pagerduty.com/documentation/rest/schedules/users and will use the account setting if we don't specify the timezone, which is what we want.