### PR TITLE
Update .gitignore to ignore .rspec-local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage/*
 .env
 *.p12
 .DS_Store
+.rspec-local


### PR DESCRIPTION
Local RSpec config (formatting etc) resides in the .rspec-local file which should not be tracked by Git.