### PR TITLE
Restore HipChat webhook

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,4 +39,4 @@ require_relative 'config/environments/test'
 # Controllers
 require_relative 'controllers/dashboard_controller'
 require_relative 'controllers/monitoring_controller'
-# require_relative 'controllers/webhooks_controller'
+require_relative 'controllers/webhooks_controller'

--- a/controllers/webhooks_controller.rb
+++ b/controllers/webhooks_controller.rb
@@ -1,0 +1,12 @@
+require_relative '../services/hipchat_webhook'
+
+class SupportApp < Sinatra::Application
+  post '/hipchat_webhook' do
+    if params.has_key?('room')
+      webhook_processor = HipchatWebhook.new(params)
+      webhook_processor.process ? 200 : 204
+    else
+      400
+    end
+  end
+end

--- a/services/hipchat_webhook.rb
+++ b/services/hipchat_webhook.rb
@@ -1,0 +1,25 @@
+class HipchatWebhook
+  REDIS_KEY_PREFIX = 'hipchat'
+
+  def initialize(payload)
+    @payload = payload
+  end
+
+  def process
+    case @payload['room']
+    when '2nd_line'
+      case @payload['message']
+      when 'problem on'
+        Flag.create(redis_key)
+      when 'problem off'
+        Flag.destroy(redis_key)
+      end
+    end
+  end
+
+  private
+
+  def redis_key
+    "#{REDIS_KEY_PREFIX}:problem_mode"
+  end
+end


### PR DESCRIPTION
Restore HipChat webhook. Removed during merge of https://github.com/ministryofjustice/2nd-line-support/pull/58